### PR TITLE
Line up simultaneous error/hint text using float instead of flexbox

### DIFF
--- a/addon/templates/components/nypr-input.hbs
+++ b/addon/templates/components/nypr-input.hbs
@@ -17,20 +17,20 @@
 {{/if}}
 
 <div class="nypr-input-footer">
+  {{#if helplinkUrl}}
+    <div class="nypr-input-helplink">
+      <a href={{helplinkUrl}}>{{helplinkText}}</a>
+    </div>
+  {{/if}}
   {{#if hasError}}
-    <span class="nypr-input-error">
+    <div class="nypr-input-error">
       {{#each errors as |error|}}
         {{{error}}}<br>
       {{/each}}
-    </span>
+    </div>
   {{else}}
     {{#if showAdvice}}
-      <span class="nypr-input-advice">{{clue}}</span>
+      <div class="nypr-input-advice">{{clue}}</div>
     {{/if}}
-  {{/if}}
-  {{#if helplinkUrl}}
-    <span class="nypr-input-helplink">
-      <a href={{helplinkUrl}}>{{helplinkText}}</a>
-    </span>
   {{/if}}
 </div>

--- a/app/styles/nypr-ui/_input.scss
+++ b/app/styles/nypr-ui/_input.scss
@@ -47,13 +47,8 @@
 }
 
 .nypr-input-footer {
-  @include display-flex;
   width: 100%;
   margin-bottom: 16px;
-
-  > span {
-    @include flex(1);
-  }
 
   .nypr-input-error {
     color: $red;
@@ -70,8 +65,11 @@
   }
 
   .nypr-input-helplink {
+    float: right;
     font-size: 14px;
     padding-top: 10px;
+    padding-left: 12px;
+    margin-bottom: 16px;
     text-align: right;
   }
 }


### PR DESCRIPTION
When we have a hint like a 'forgot password' link, there's less room
for error messages.  This change lets the error messages take as much
room as they can as well as use the space below the link if they run
long enough to need it.

https://jira.wnyc.org/browse/WE-6506