### PR TITLE
add onChange and onInput properties to nypr-input

### DIFF
--- a/addon/components/nypr-input.js
+++ b/addon/components/nypr-input.js
@@ -8,11 +8,11 @@ export default Component.extend({
   classNames: ['nypr-input-container'],
   classNameBindings: ['hasError'],
   type: 'text',
-  entered: false,
-  exited: false,
+  focused: false,
+  blurred: false,
   submitted: false,
-  showError: or('exited', 'submitted'),
-  showAdvice: and('entered', 'clue'),
+  showError: or('blurred', 'submitted'),
+  showAdvice: and('focused', 'clue'),
   hasError: and('errors', 'showError'),
   showValidMark: computed('validMark', 'hasError', 'disabled', function() {
     if (!this.get('validMark')) {

--- a/addon/templates/components/nypr-input.hbs
+++ b/addon/templates/components/nypr-input.hbs
@@ -7,8 +7,9 @@
   class="nypr-input"
   value=value
   disabled=disabled
-  focus-in=(action (mut entered) true)
-  focus-out=(action (mut exited) true)}}
+  focus-in=(action (mut focused) true)
+  focus-out=(action (mut blurred) true)
+  }}
 {{#if showValidMark}}
   {{nypr-svg className="nypr-input-validmark" icon="checkmark"}}
 {{/if}}

--- a/addon/templates/components/nypr-input.hbs
+++ b/addon/templates/components/nypr-input.hbs
@@ -9,6 +9,8 @@
   disabled=disabled
   focus-in=(action (mut focused) true)
   focus-out=(action (mut blurred) true)
+  change=onChange
+  input=onInput
   }}
 {{#if showValidMark}}
   {{nypr-svg className="nypr-input-validmark" icon="checkmark"}}

--- a/tests/integration/components/nypr-input-test.js
+++ b/tests/integration/components/nypr-input-test.js
@@ -64,4 +64,54 @@ test('it shows advice text at the right times', function(assert) {
   assert.equal(this.$('.nypr-input-advice').length, 0, "it should not show advice when it shows an error");
 });
 
+test('it shows advice text at the right times', function(assert) {
+  let testClue = 'format: ###';
+  this.set('clue', testClue);
+  this.set('errors', undefined);
+  this.render(hbs`{{nypr-input clue=clue errors=errors}}`);
+  assert.equal(this.$('.nypr-input-advice').length, 0, "it should not show advice before focus");
+
+  this.$('.nypr-input').trigger('focusin');
+  assert.equal(this.$('.nypr-input-advice').length, 1, "it should show advice on focus");
+  assert.equal(this.$('.nypr-input-advice').text().trim(), testClue, "it should show the correct advice");
+
+  this.$('.nypr-input').trigger('focusout');
+  assert.equal(this.$('.nypr-input-advice').length, 1, "it should keep showing advice after touched (focusout)");
+
+  this.set('errors', ['bad input']);
+  assert.equal(this.$('.nypr-input-advice').length, 0, "it should not show advice when it shows an error");
+});
+
+test('it calls the onChange event', function(assert) {
+  let onChangeCalls = [];
+  this.set('changeAction', (e) => {
+    onChangeCalls.push(e);
+  });
+
+  this.render(hbs`{{nypr-input onChange=(action changeAction)}}`);
+
+  this.$('.nypr-input').val('abc');
+  this.$('.nypr-input').change();
+
+  assert.equal(onChangeCalls.length, 1);
+});
+
+
+test('it calls the onInput event', function(assert) {
+  let onInputCalls = [];
+  this.set('inputAction', (e) => {
+    onInputCalls.push(e);
+  });
+
+  this.render(hbs`{{nypr-input onInput=(action inputAction)}}`);
+
+  this.$('.nypr-input').val('a');
+  this.$('.nypr-input').trigger('input');
+  this.$('.nypr-input').val('ab');
+  this.$('.nypr-input').trigger('input');
+  this.$('.nypr-input').val('abc');
+  this.$('.nypr-input').trigger('input');
+
+  assert.equal(onInputCalls.length, 3);
+});
 

--- a/tests/integration/components/nypr-input-test.js
+++ b/tests/integration/components/nypr-input-test.js
@@ -64,24 +64,6 @@ test('it shows advice text at the right times', function(assert) {
   assert.equal(this.$('.nypr-input-advice').length, 0, "it should not show advice when it shows an error");
 });
 
-test('it shows advice text at the right times', function(assert) {
-  let testClue = 'format: ###';
-  this.set('clue', testClue);
-  this.set('errors', undefined);
-  this.render(hbs`{{nypr-input clue=clue errors=errors}}`);
-  assert.equal(this.$('.nypr-input-advice').length, 0, "it should not show advice before focus");
-
-  this.$('.nypr-input').trigger('focusin');
-  assert.equal(this.$('.nypr-input-advice').length, 1, "it should show advice on focus");
-  assert.equal(this.$('.nypr-input-advice').text().trim(), testClue, "it should show the correct advice");
-
-  this.$('.nypr-input').trigger('focusout');
-  assert.equal(this.$('.nypr-input-advice').length, 1, "it should keep showing advice after touched (focusout)");
-
-  this.set('errors', ['bad input']);
-  assert.equal(this.$('.nypr-input-advice').length, 0, "it should not show advice when it shows an error");
-});
-
 test('it calls the onChange event', function(assert) {
   let onChangeCalls = [];
   this.set('changeAction', (e) => {


### PR DESCRIPTION
these properties take actions as their values, and trigger when the internal input element fires 'change' or 'input' events.