### PR TITLE
refactors nypr mini chrome

### DIFF
--- a/addon/templates/components/nypr-mini-chrome.hbs
+++ b/addon/templates/components/nypr-mini-chrome.hbs
@@ -1,6 +1,6 @@
 <div class="nypr-mini-chrome-top">
-    <a href="/" class="link--nodecor logo">{{nypr-svg icon='wnyc-logo' className='wnyc-logo'}}</a>
-    <div class="tune-in">Tune in Monday−Thursday at 8 p.m. ET</div>
+    <a href="/" class="link--nodecor nypr-mini-chrome-left">{{nypr-svg icon='wnyc-logo' className='wnyc-logo'}}</a>
+    <div class="nypr-mini-chrome-right">{{{promo}}}</div>
 </div>
 
 {{yield}}

--- a/app/styles/nypr-ui/_mini-chrome.scss
+++ b/app/styles/nypr-ui/_mini-chrome.scss
@@ -3,39 +3,38 @@
 }
 
 .nypr-mini-chrome-top {
-  padding: 15px 25px;
+  padding: 18px 25px;
   background-color: black;
   display: flex;
   align-items: center;
   justify-content: space-between;
 
-  .tune-in {
-    color: white;
-    text-align: right;
+  @media (min-width: 401px) {
+    padding-top: 15px;
+    padding-bottom: 15px;
+  }
+}
 
-    @media (max-width: 400px) {
-      font-size: 12px;
-      font-weight: 700;
-      margin-left: 10px;
+.nypr-mini-chrome-left {
+  display: flex;
+
+  svg {
+    width: 77px;
+    height: 30px;
+
+    path {
+      fill: white;
     }
   }
+}
+
+.nypr-mini-chrome-right {
+  color: white;
+  text-align: right;
 
   @media (max-width: 400px) {
-    * {
-      margin: 3px 0;
-    }
-  }
-
-  .logo {
-    display: flex;
-
-    svg {
-      width: 77px;
-      height: 30px;
-
-      path {
-        fill: white;
-      }
-    }
+    font-size: 12px;
+    font-weight: 700;
+    margin-left: 10px;
   }
 }

--- a/tests/integration/components/nypr-mini-chrome-test.js
+++ b/tests/integration/components/nypr-mini-chrome-test.js
@@ -10,9 +10,9 @@ test('it renders', function(assert) {
   // Set any properties with this.set('myProperty', 'value');
   // Handle any actions with this.on('myAction', function(val) { ... });
 
-  this.render(hbs`{{nypr-mini-chrome}}`);
+  this.render(hbs`{{nypr-mini-chrome promo="Promo message"}}`);
 
-  assert.equal(this.$().text().trim(), '');
+  assert.equal(this.$().text().trim(), 'Promo message');
 
   // Template block usage:
   this.render(hbs`


### PR DESCRIPTION
there was hard-coded text in the template. this refactors it out so that
consuming apps can pass in whatever they want.

There was also a * selector which we should generally avoid in our CSS.
This patch moves that additional spacing to padding on the containing
`.nypr-mini-chrome-top` element instead of adding a margin to all
child nodes.