### PR TITLE
WE-7454 Fix weird underline rendering on story page links

### DIFF
--- a/app/styles/nypr-ui/_story.scss
+++ b/app/styles/nypr-ui/_story.scss
@@ -41,7 +41,7 @@ article {
     }
 
     a {
-      border-bottom: .08em solid rgba(black, .1);
+      border-bottom: 1px solid rgba(black, .1);
     }
 
     blockquote {


### PR DESCRIPTION
Use px instead of em for border width. I think using .08em here was creating a weird subpixel border width that browsers were not handling well and it animated weirdly during the hover transition. 