### PR TITLE
Tweak image credits in nypr-hero

### DIFF
--- a/addon/templates/components/hero.hbs
+++ b/addon/templates/components/hero.hbs
@@ -1,6 +1,6 @@
 {{#if hasBlock}}
   <div class={{concat 'image-container' (if gradient ' with-gradient')}} style={{backgroundImage}}>
-    {{yield (hash 
+    {{yield (hash
       image=(component 'nypr-ui/hero/image'
              sendImage=(action setImage)
              useBackgroundImage=useBackgroundImage
@@ -11,10 +11,10 @@
       footer=(component 'nypr-ui/hero/footer')
     )}}
   </div>
-  
+
   {{#if (or source credit caption)}}
     <span class="hero-source">
-      {{caption}}{{#if (or credit source)}} ({{credit}}{{if source ' / '}}{{link-or-text source}}){{/if}}
+      {{caption}}{{#if (or credit source)}} ({{credit}}{{if (and credit source) ' / '}}{{{link-or-text source}}}){{/if}}
     </span>
   {{/if}}
 {{else}}

--- a/tests/integration/helpers/link-or-text-test.js
+++ b/tests/integration/helpers/link-or-text-test.js
@@ -6,12 +6,22 @@ moduleForComponent('link-or-text', 'helper:link-or-text', {
   integration: true
 });
 
-// Replace this with your real tests.
-test('it renders', function(assert) {
+test('it renders link', function(assert) {
+  let name = 'link';
+  let url = 'http://example.com';
+  this.set('inputValue', {name, url});
+
+  this.render(hbs`{{{link-or-text inputValue}}}`);
+
+  assert.equal(this.$('a').length, 1);
+  assert.equal(this.$('a').text(), name);
+  assert.equal(this.$('a').attr('href'), url);
+});
+
+test('it renders text', function(assert) {
   this.set('inputValue', '1234');
 
   this.render(hbs`{{link-or-text inputValue}}`);
 
   assert.equal(this.$().text().trim(), '1234');
 });
-


### PR DESCRIPTION
- Use triple brackets so sources that are links work
- Don't show the `/` if we have a source but no credit