### PR TITLE
remove target=blank in share buttons

### DIFF
--- a/addon/templates/components/nypr-story/share-buttons.hbs
+++ b/addon/templates/components/nypr-story/share-buttons.hbs
@@ -6,7 +6,7 @@
     <i class="fa fa-twitter"></i>
     <span class="for-screenreaders">Share on Twitter</span>
   </button>
-  <a href="mailto:?subject={{url-encode story.title}}&body={{story.url}}" class="btn btn--circle btn--mq-graywhite" data-category="SharedE" id="shareEmail" title="Email a Friend" target="_blank" data-action="Email">
+  <a href="mailto:?subject={{url-encode story.title}}&body={{story.url}}" class="btn btn--circle btn--mq-graywhite" data-category="SharedE" id="shareEmail" title="Email a Friend" data-action="Email">
     <i class="fa fa-envelope"></i>
     <span class="for-screenreaders">Email a Friend</span>
   </a>


### PR DESCRIPTION
doesn't affect audio playback/ember route resolution if target="_blank" isn't used, doesn't open empty tab