### PR TITLE
Web Client Tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -103,7 +103,7 @@ jobs:
           key: bower-deps-{{ checksum "bower.json" }}
 
       - attach_workspace:
-          at: ~
+          at: ~/wnyc-web-client
 
       - restore_cache:
           key: bower-deps-{{ checksum "~/wnyc-web-client/bower.json" }}

--- a/circle.yml
+++ b/circle.yml
@@ -71,7 +71,7 @@ jobs:
       - run:
           name: clone clients
           command: |
-            for client in "wnyc wqxr new-sounds wnyc-studios"; do
+            for client in wnyc wqxr new-sounds wnyc-studios; do
               git clone git@github.com:nypublicradio/$client-web-client
             done
       - persist_to_workspace:

--- a/circle.yml
+++ b/circle.yml
@@ -148,12 +148,12 @@ jobs:
       CIRCLE_TEST_REPORTS: wnyc-test-results
 
     steps:
-      <<: *link_nypr_ui
-      <<: *client_install_node
-      <<: *client_install_bower
-      <<: *client_build_modernizr
+      - <<: *link_nypr_ui
+      - <<: *client_install_node
+      - <<: *client_install_bower
+      - <<: *client_build_modernizr
 
-      <<: *client_test_steps
+      - <<: *client_test_steps
 
       - store_test_results:
           path: wnyc-test-results/
@@ -166,12 +166,12 @@ jobs:
       CIRCLE_TEST_REPORTS: wqxr-test-results
 
     steps:
-      <<: *link_nypr_ui
-      <<: *client_install_node
-      <<: *client_install_bower
-      <<: *client_build_modernizr
+      - <<: *link_nypr_ui
+      - <<: *client_install_node
+      - <<: *client_install_bower
+      - <<: *client_build_modernizr
 
-      <<: *client_test_steps
+      - <<: *client_test_steps
 
       - store_test_results:
           path: wqxr-test-results/
@@ -183,10 +183,10 @@ jobs:
       CIRCLE_TEST_REPORTS: new-sounds-test-results
 
     steps:
-      <<: *link_nypr_ui
-      <<: *client_install_node
+      - <<: *link_nypr_ui
+      - <<: *client_install_node
 
-      <<: *client_test_steps
+      - <<: *client_test_steps
 
       - store_test_results:
           path: new-sounds-test-results/
@@ -199,9 +199,9 @@ jobs:
       CIRCLE_TEST_REPORTS: wnyc-studios-test-results
 
     steps:
-      <<: *link_nypr_ui
-      <<: *client_install_node
-      <<: *client_build_modernizr
+      - <<: *link_nypr_ui
+      - <<: *client_install_node
+      - <<: *client_build_modernizr
 
       - run: |
           cp .env.sample .env
@@ -218,9 +218,9 @@ jobs:
       CIRCLE_TEST_REPORTS: wnyc-studios-test-results
 
     steps:
-      <<: *link_nypr_ui
-      <<: *client_install_node
-      <<: *client_build_modernizr
+      - <<: *link_nypr_ui
+      - <<: *client_install_node
+      - <<: *client_build_modernizr
 
       - run: |
           cp .env.sample .env

--- a/circle.yml
+++ b/circle.yml
@@ -70,6 +70,7 @@ jobs:
     steps:
       - add_ssh_keys:
           fingerprints:
+            - "c5:68:42:20:05:ba:99:2f:9f:07:22:46:30:71:ca:a1" # for studios
             - "8b:44:88:9d:98:b1:2e:01:c9:95:40:1d:3e:45:ed:42" # for new sounds
       - run:
           name: Keyscan Github

--- a/circle.yml
+++ b/circle.yml
@@ -9,27 +9,27 @@ jobs:
       - checkout
 
       - restore_cache:
-          key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
+          key: nypr-ui-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
       - run:
           name: Install node dependencies
           command: |
-            if [ ! -d ./node_modules ]; then
+            if [ ! -d node_modules ]; then
               yarn --pure-lockfile
             fi
       - save_cache:
-          key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
+          key: nypr-ui-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
           paths:
-            - ./node_modules
+            - node_modules
 
       - restore_cache:
-          key: bower-deps-{{ checksum "bower.json" }}
+          key: nypr-ui-bower-deps-{{ checksum "bower.json" }}
       - run:
           name: Install bower dependencies
           command: npx bower i
       - save_cache:
-          key: bower-deps-{{ checksum "bower.json" }}
+          key: nypr-ui-bower-deps-{{ checksum "bower.json" }}
           paths:
-            - ./bower_components
+            - bower_components
 
   test:
     working_directory: /home/circleci/nypr-ui
@@ -41,9 +41,10 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
+          key: nypr-ui-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
       - restore_cache:
-          key: bower-deps-{{ checksum "bower.json" }}
+          key: nypr-ui-bower-deps-{{ checksum "bower.json" }}
+
       - run:
           name: greenkeeper-lockfile
           command: yarn global add greenkeeper-lockfile@1
@@ -70,11 +71,6 @@ jobs:
     working_directory: /home/circleci
     steps:
       - run:
-          name: Keyscan Github
-          command: |
-            mkdir ~/.ssh
-            ssh-keyscan -H github.com >> ~/.ssh/known_hosts
-      - run:
           name: clone clients
           command: |
             for client in wnyc wqxr new-sounds wnyc-studios; do
@@ -97,17 +93,16 @@ jobs:
       - image: circleci/node:8.7-browsers
         environment:
           JOBS: 2
-          ADDON_DIR: /home/circleci/nypr-ui
 
     steps:
       - checkout
       - restore_cache:
-          key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "$ADDON_DIR/yarn.lock" }}
+          key: nypr-ui-yarn-deps-{{ arch }}-{{ checksum "/home/circleci/nypr-ui/yarn.lock" }}
       - restore_cache:
-          key: bower-deps-{{ checksum "$ADDON_DIR/bower.json" }}
+          key: nypr-ui-bower-deps-{{ checksum "/home/circleci/nypr-ui/bower.json" }}
       - run:
           name: make global symlink
-          command: yarn link
+          command: cd /home/circleci/nypr-ui && yarn link
 
       - attach_workspace:
           at: /home/circleci
@@ -127,7 +122,7 @@ jobs:
       - run:
           name: node deps
           command: |
-            if [ ! -d ./node_modules ]; then
+            if [ ! -d node_modules ]; then
               yarn --pure-lockfile
             fi
       - save_cache:
@@ -319,9 +314,9 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
+          key: nypr-ui-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
       - restore_cache:
-          key: bower-deps-{{ checksum "bower.json" }}
+          key: nypr-ui-bower-deps-{{ checksum "bower.json" }}
       - add_ssh_keys:
           fingerprints:
             - "46:1b:e7:bf:91:16:06:e2:79:99:fd:3d:00:c1:28:0a"

--- a/circle.yml
+++ b/circle.yml
@@ -65,7 +65,7 @@ jobs:
 
   test_wnyc:
     docker:
-      - images: circleci/node:8.7-browsers
+      - image: circleci/node:8.7-browsers
         environment:
           JOBS: 2
 
@@ -123,7 +123,7 @@ jobs:
 
   test_wqxr:
     docker:
-      - images: circleci/node:8.7-browsers
+      - image: circleci/node:8.7-browsers
         environment:
           JOBS: 2
 
@@ -180,7 +180,7 @@ jobs:
 
   test_new_sounds:
     docker:
-      - images: circleci/node:8.7-browsers
+      - image: circleci/node:8.7-browsers
         environment:
           JOBS: 2
 
@@ -223,7 +223,7 @@ jobs:
   test_wnyc_studios:
     parallelism: 4
     docker:
-      - images: circleci/node:8.7-browsers
+      - image: circleci/node:8.7-browsers
         environment:
           JOBS: 2
 

--- a/circle.yml
+++ b/circle.yml
@@ -219,7 +219,13 @@ workflows:
           filters:
             branches:
               only: qa-build
-      - test_wnyc_studios:
+      - test_wnyc_studios_ember:
+          requires:
+            - setup_test_clients
+          filters:
+            branches:
+              only: qa-build
+      - test_wnyc_studios_cypress:
           requires:
             - setup_test_clients
           filters:
@@ -236,7 +242,8 @@ workflows:
             - test
             - test_wnyc
             - test_wqxr
-            - test_wnyc_studios
+            - test_wnyc_studios_ember
+            - test_wnyc_studios_cypress
             - test_new_sounds
           filters:
             branches:

--- a/circle.yml
+++ b/circle.yml
@@ -1,5 +1,11 @@
 version: 2
 
+container_defaults: &defaults
+  docker:
+    - image: circleci/node:8.7-browsers
+      environment:
+        JOBS: 2
+
 jobs:
   install:
     <<: *defaults
@@ -373,9 +379,3 @@ workflows:
           filters:
             branches:
               only: master
-
-container_defaults: &defaults
-  docker:
-    - image: circleci/node:8.7-browsers
-      environment:
-        JOBS: 2

--- a/circle.yml
+++ b/circle.yml
@@ -53,7 +53,10 @@ client_test_steps: &client_test_steps
 
 jobs:
   install:
-    <<: *defaults
+    docker:
+      - image: circleci/node:8.7-browsers
+        environment:
+          JOBS: 2
     working_directory: /home/circleci/nypr-ui
     steps:
       - checkout

--- a/circle.yml
+++ b/circle.yml
@@ -94,11 +94,13 @@ jobs:
       - <<: *restore_node
       - <<: *restore_bower
 
-      - run: |
-          sudo yarn global add greenkeeper-lockfile@1
-          greenkeeper-lockfile-update
-          npx ember test
-          greenkeeper-lockfile-upload
+      - run:
+          name: Run addon tests
+          command: |
+            sudo yarn global add greenkeeper-lockfile@1
+            greenkeeper-lockfile-update
+            npx ember test
+            greenkeeper-lockfile-upload
 
       - store_test_results:
           path: test-results/

--- a/circle.yml
+++ b/circle.yml
@@ -11,7 +11,7 @@ register_nypr_ui: &register_nypr_ui
 
 restore_node: &restore_node
   restore_cache:
-    key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
+    key: node-deps-{{ arch }}-{{ checksum "yarn.lock" }}
 
 install_node: &install_node
   run:
@@ -23,13 +23,13 @@ install_node: &install_node
 
 save_node: &save_node
   save_cache:
-    key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
+    key: node-deps-{{ arch }}-{{ checksum "yarn.lock" }}
     paths:
       - node_modules
 
 restore_bower: &restore_bower
   restore_cache:
-    key: bower-deps-{{ checksum "bower.json" }}
+    key: bower-deps-{{ arch }}-{{ checksum "bower.json" }}
 
 install_bower: &install_bower
   run:
@@ -41,7 +41,7 @@ install_bower: &install_bower
 
 save_bower: &save_bower
   save_cache:
-    key: bower-deps-{{ checksum "bower.json" }}
+    key: bower-deps-{{ arch }}-{{ checksum "bower.json" }}
     paths:
       - bower_components
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,5 +1,62 @@
 version: 2
 
+attach: &attach
+  attach_workspace:
+    at: /home/circleci
+
+register_nypr_ui: &register_nypr_ui
+  run:
+    name: make global symlink
+    command: cd /home/circleci/nypr-ui && yarn link
+
+restore_node: &restore_node
+  restore_cache:
+    key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
+
+install_node: &install_node
+  run:
+    name: node deps
+    command: |
+      if [ ! -d node_modules ]; then
+        yarn --pure-lockfile
+      fi
+
+save_node: &save_node
+  save_cache:
+    key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
+    paths:
+      - node_modules
+
+restore_bower: &restore_bower
+  restore_cache:
+    key: bower-deps-{{ checksum "bower.json" }}
+
+install_bower: &install_bower
+  run:
+    name: bower deps
+    command: |
+      if [ ! -d bower_components ]; then
+        npx bower i
+      fi
+
+save_bower: &save_bower
+  save_cache:
+    key: bower-deps-{{ checksum "bower.json" }}
+    paths:
+      - bower_components
+
+build_modernizr: &build_modernizr
+  run:
+    name: Build modernizr
+    command: npx grunt modernizr:dist
+
+run_client_tests: &run_client_tests
+  run:
+    name: link and test
+    command: |
+      yarn link nypr-ui
+      npx ember test
+
 container_defaults: &defaults
   docker:
     - image: circleci/node:8.7-browsers
@@ -13,28 +70,13 @@ jobs:
     steps:
       - checkout
 
-      - restore_cache:
-          key: nypr-ui-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
-      - run:
-          name: Install node dependencies
-          command: |
-            if [ ! -d node_modules ]; then
-              yarn --pure-lockfile
-            fi
-      - save_cache:
-          key: nypr-ui-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
-          paths:
-            - node_modules
+      - <<: *restore_node
+      - <<: *install_node
+      - <<: *save_node
 
-      - restore_cache:
-          key: nypr-ui-bower-deps-{{ checksum "bower.json" }}
-      - run:
-          name: Install bower dependencies
-          command: npx bower i
-      - save_cache:
-          key: nypr-ui-bower-deps-{{ checksum "bower.json" }}
-          paths:
-            - bower_components
+      - <<: *restore_bower
+      - <<: *install_bower
+      - <<: *save_bower
 
       - persist_to_workspace:
           root: /home/circleci
@@ -44,31 +86,18 @@ jobs:
   test:
     <<: *defaults
     working_directory: /home/circleci/nypr-ui
+    environment:
+      CIRCLE_TEST_REPORTS: test-results
 
     steps:
       - checkout
-      - restore_cache:
-          key: nypr-ui-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
-      - restore_cache:
-          key: nypr-ui-bower-deps-{{ checksum "bower.json" }}
+      - <<: *restore_node
+      - <<: *restore_bower
 
-      - run:
-          name: greenkeeper-lockfile
-          command: yarn global add greenkeeper-lockfile@1
-      - run:
-          name: Add Yarn global bin to path
-          command: echo 'export PATH=$PATH:`yarn global bin`' >> $BASH_ENV
-      - run:
-          name: greenkeeper-lockfile-update
-          command: greenkeeper-lockfile-update
-      - run:
-          name: Test
-          environment:
-            CIRCLE_TEST_REPORTS: test-results
-          command: npx ember test
-      - run:
-          name: greenkeeper-lockfile-upload
-          command: greenkeeper-lockfile-upload
+      - run: yarn global add greenkeeper-lockfile@1
+      - run: greenkeeper-lockfile-update
+      - run: npx ember test
+      - run: greenkeeper-lockfile-upload
       - store_test_results:
           path: test-results/
 
@@ -103,45 +132,20 @@ jobs:
       CIRCLE_TEST_REPORTS: wnyc-test-results
 
     steps:
-      - attach_workspace:
-          at: /home/circleci
-      - run:
-          name: make global symlink
-          command: cd /home/circleci/nypr-ui && yarn link
+      - <<: *attach
+      - <<: *register_nypr_ui
 
-      - restore_cache:
-          key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
-      - run:
-          name: node deps
-          command: |
-            if [ ! -d node_modules ]; then
-              yarn --pure-lockfile
-            fi
-      - save_cache:
-          key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
-          paths:
-            - node_modules
+      - <<: *restore_node
+      - <<: *install_node
+      - <<: *save_node
 
-      - restore_cache:
-          key: bower-deps-{{ checksum "bower.json" }}
-      - run:
-          name: bower deps
-          command: npx bower i
-      - save_cache:
-          key: bower-deps-{{ checksum "bower.json" }}
-          paths:
-            - bower_components
+      - <<: *restore_bower
+      - <<: *install_bower
+      - <<: *save_bower
 
-      - run:
-          name: Build modernizr
-          command: npx grunt modernizr:dist || true
+      - <<: *build_modernizr
 
-      - run:
-          name: link and test
-          environment:
-          command: |
-            yarn link nypr-ui
-            npx ember test
+      - <<: *run_client_tests
 
       - store_test_results:
           path: wnyc-test-results/
@@ -154,45 +158,20 @@ jobs:
       CIRCLE_TEST_REPORTS: wqxr-test-results
 
     steps:
-      - attach_workspace:
-          at: /home/circleci
-      - run:
-          name: make global symlink
-          command: cd /home/circleci/nypr-ui && yarn link
+      - <<: *attach
+      - <<: *register_nypr_ui
 
-      - restore_cache:
-          key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
-      - run:
-          name: node deps
-          command: |
-            if [ ! -d node_modules ]; then
-              yarn --pure-lockfile
-            fi
-      - save_cache:
-          key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
-          paths:
-            - node_modules
+      - <<: *restore_node
+      - <<: *install_node
+      - <<: *save_node
 
-      - restore_cache:
-          key: bower-deps-{{ checksum "bower.json" }}
-      - run:
-          name: bower deps
-          command: npx bower i
-      - save_cache:
-          key: bower-deps-{{ checksum "bower.json" }}
-          paths:
-            - bower_components
+      - <<: *restore_bower
+      - <<: *install_bower
+      - <<: *save_bower
 
-      - run:
-          name: Build modernizr
-          command: npx grunt modernizr:dist
+      - <<: *build_modernizr
 
-      - run:
-          name: link and test
-          environment:
-          command: |
-            yarn link nypr-ui
-            npx ember test
+      - <<: *run_client_tests
 
       - store_test_results:
           path: wqxr-test-results/
@@ -204,31 +183,14 @@ jobs:
       CIRCLE_TEST_REPORTS: new-sounds-test-results
 
     steps:
-      - attach_workspace:
-          at: /home/circleci
-      - run:
-          name: make global symlink
-          command: cd /home/circleci/nypr-ui && yarn link
+      - <<: *attach
+      - <<: *register_nypr_ui
 
-      - restore_cache:
-          key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
-      - run:
-          name: node deps
-          command: |
-            if [ ! -d node_modules ]; then
-              yarn --pure-lockfile
-            fi
-      - save_cache:
-          key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
-          paths:
-            - node_modules
+      - <<: *restore_node
+      - <<: *install_node
+      - <<: *save_node
 
-      - run:
-          name: link and test
-          environment:
-          command: |
-            yarn link nypr-ui
-            npx ember test
+      - <<: *run_client_tests
 
       - store_test_results:
           path: new-sounds-test-results/
@@ -241,28 +203,14 @@ jobs:
       CIRCLE_TEST_REPORTS: wnyc-studios-test-results
 
     steps:
-      - attach_workspace:
-          at: /home/circleci
-      - run:
-          name: make global symlink
-          command: cd /home/circleci/nypr-ui && yarn link
+      - <<: *attach
+      - <<: *register_nypr_ui
 
-      - restore_cache:
-          key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
-      - run:
-          name: node deps
-          command: |
-            if [ ! -d node_modules ]; then
-              yarn --pure-lockfile
-            fi
-      - save_cache:
-          key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
-          paths:
-            - node_modules
+      - <<: *restore_node
+      - <<: *install_node
+      - <<: *save_node
 
-      - run:
-          name: Build modernizr
-          command: npx grunt modernizr:dist
+      - <<: *build_modernizr
 
       - run: |
           cp .env.sample .env
@@ -279,28 +227,14 @@ jobs:
       CIRCLE_TEST_REPORTS: wnyc-studios-test-results
 
     steps:
-      - attach_workspace:
-          at: /home/circleci
-      - run:
-          name: make global symlink
-          command: cd /home/circleci/nypr-ui && yarn link
+      - <<: *attach
+      - <<: *register_nypr_ui
 
-      - restore_cache:
-          key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
-      - run:
-          name: node deps
-          command: |
-            if [ ! -d node_modules ]; then
-              yarn --pure-lockfile
-            fi
-      - save_cache:
-          key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
-          paths:
-            - node_modules
+      - <<: *restore_node
+      - <<: *install_node
+      - <<: *save_node
 
-      - run:
-          name: Build modernizr
-          command: npx grunt modernizr:dist
+      - <<: *build_modernizr
 
       - run: |
           cp .env.sample .env
@@ -315,8 +249,7 @@ jobs:
     <<: *defaults
     working_directory: /home/circleci/nypr-ui
     steps:
-      - attach_workspace:
-          at: /home/circleci
+      - <<: *attach
       - run:
          name: Deploy to GitHub Pages
          command: |

--- a/circle.yml
+++ b/circle.yml
@@ -95,9 +95,9 @@ jobs:
       - <<: *restore_bower
 
       - run: yarn global add greenkeeper-lockfile@1
-      - run: greenkeeper-lockfile-update
+      - run: npx greenkeeper-lockfile-update
       - run: npx ember test
-      - run: greenkeeper-lockfile-upload
+      - run: npx greenkeeper-lockfile-upload
       - store_test_results:
           path: test-results/
 

--- a/circle.yml
+++ b/circle.yml
@@ -22,13 +22,14 @@ jobs:
           key: bower-deps-{{ checksum "bower.json" }}
       - run:
           name: Install bower dependencies
-          command: |
-            yarn global add bower
-            npx bower i
+          command: npx bower i
       - save_cache:
           key: bower-deps-{{ checksum "bower.json" }}
           paths:
             - ./bower_components
+      - run:
+          name: make global symlink
+          command: yarn link
 
   test:
     docker:
@@ -62,6 +63,215 @@ jobs:
       - store_test_results:
           path: test-results/
 
+  test_wnyc:
+    docker:
+      - images: circleci/node:8.7-browsers
+        environment:
+          JOBS: 2
+
+    steps:
+      - checkout
+      - store_test_results:
+          path: wnyc-test-results/
+      - restore_cache:
+          key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
+      - restore_cache:
+          key: bower-deps-{{ checksum "bower.json" }}
+
+      - run:
+          name: clone wnyc
+          command: |
+            cd ~
+            git clone git@github.com:nypublicradio/wnyc-web-client
+            cd ~/wnyc-web-client
+
+      - restore_cache:
+          key: bower-deps-{{ checksum "bower.json" }}
+      - run:
+          name: wnyc bower deps
+          command: npx bower i
+      - save_cache:
+          key: bower-deps-{{ checksum "bower.json" }}
+          paths:
+            - bower_components
+
+      - restore_cache:
+          key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
+      - run:
+          name: wnyc node deps
+          command: |
+            if [ ! -d ./node_modules ]; then
+              yarn --pure-lockfile
+            fi
+      - save_cache:
+          key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
+          paths:
+            - node_modules
+
+      - run:
+          name: Build modernizr
+          command: npx grunt modernizr:dist
+
+      - run:
+          name: link and test
+          environment:
+            CIRCLE_TEST_REPORTS: wnyc-test-results
+          command: |
+            yarn link nypr-ui
+            npx ember test
+
+
+  test_wqxr:
+    docker:
+      - images: circleci/node:8.7-browsers
+        environment:
+          JOBS: 2
+
+    steps:
+      - checkout
+      - store_test_results:
+          path: wqxr-test-results/
+      - restore_cache:
+          key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
+      - restore_cache:
+          key: bower-deps-{{ checksum "bower.json" }}
+
+      - run:
+          name: clone wqxr
+          command: |
+            cd ~
+            git clone git@github.com:nypublicradio/wqxr-web-client
+            cd ~/wqxr-web-client
+
+      - restore_cache:
+          key: bower-deps-{{ checksum "bower.json" }}
+      - run:
+          name: wqxr bower deps
+          command: npx bower i
+      - save_cache:
+          key: bower-deps-{{ checksum "bower.json" }}
+          paths:
+            - bower_components
+
+      - restore_cache:
+          key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
+      - run:
+          name: wqxr node deps
+          command: |
+            if [ ! -d ./node_modules ]; then
+              yarn --pure-lockfile
+            fi
+      - save_cache:
+          key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
+          paths:
+            - node_modules
+
+      - run:
+          name: Build modernizr
+          command: npx grunt modernizr:dist
+
+      - run:
+          name: link and test
+          environment:
+            CIRCLE_TEST_REPORTS: wqxr-test-results
+          command: |
+            yarn link nypr-ui
+            npx ember test
+
+  test_new_sounds:
+    docker:
+      - images: circleci/node:8.7-browsers
+        environment:
+          JOBS: 2
+
+    steps:
+      - checkout
+      - store_test_results:
+          path: new-sounds-test-results/
+      - restore_cache:
+          key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
+      - restore_cache:
+          key: bower-deps-{{ checksum "bower.json" }}
+      - run:
+          name: clone new sounds
+          command: |
+            cd ~
+            git clone git@github.com:nypublicradio/new-sounds-web-client
+            cd ~/new-sounds-web-client
+
+      - restore_cache:
+          key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
+      - run:
+          name: new sounds node deps
+          command: |
+            if [ ! -d ./node_modules ]; then
+              yarn --pure-lockfile
+            fi
+      - save_cache:
+          key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
+          paths:
+            - node_modules
+
+        - run:
+            name: link and test
+          environment:
+            CIRCLE_TEST_REPORTS: new-sounds-test-results
+          command: |
+            yarn link nypr-ui
+            npx ember test
+
+  test_wnyc_studios:
+    parallelism: 4
+    docker:
+      - images: circleci/node:8.7-browsers
+        environment:
+          JOBS: 2
+
+    steps:
+      - checkout
+      - store_test_results:
+          path: wnyc-studios-test-results/
+      - restore_cache:
+          key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
+      - restore_cache:
+          key: bower-deps-{{ checksum "bower.json" }}
+
+      - run:
+          name: clone wnyc studios
+          command: |
+            cd ~
+            git clone git@github.com:nypublicradio/wnyc-studios-web-client
+            cd ~/wnyc-studios-web-client
+
+      - restore_cache:
+          key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
+      - run:
+          name: wqxr node deps
+          command: |
+            if [ ! -d ./node_modules ]; then
+              yarn --pure-lockfile
+            fi
+      - save_cache:
+          key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
+          paths:
+            - node_modules
+
+      - run:
+          name: Build modernizr
+          command: npx grunt modernizr:dist
+
+      - run:
+          name: link and test
+          environment:
+            CIRCLE_TEST_REPORTS: wnyc-studios-test-results
+          command: |
+            yarn link nypr-ui
+            npx ember exam --split=$CIRCLE_NODE_TOTAL --partition=$(($CIRCLE_NODE_INDEX + 1))
+            sudo apt-get install libgconf-2-4
+            cp .env.sample .env
+            yarn run cy:ci:test
+
+
   deploy:
     docker:
       - image: circleci/node:8.7
@@ -91,9 +301,37 @@ workflows:
       - test:
           requires:
             - install
+      - test_wnyc:
+          requires:
+            - install
+          filters:
+            branches:
+              only: qa-build
+      - test_wqxr:
+          requires:
+            - install
+          filters:
+            branches:
+              only: qa-build
+      - test_wnyc_studios:
+          requires:
+            - install
+          filters:
+            branches:
+              only: qa-build
+      - test_new_sounds:
+          requires:
+            - install
+          filters:
+            branches:
+              only: qa-build
       - deploy:
           requires:
             - test
+            - test_wnyc
+            - test_wqxr
+            - test_wnyc_studios
+            - test_new_sounds
           filters:
             branches:
               only: master

--- a/circle.yml
+++ b/circle.yml
@@ -69,9 +69,6 @@ jobs:
     working_directory: ~
     steps:
       - run:
-          name: Keyscan Github
-          command: ssh-keyscan -H github.com >> ~/.ssh/known_hosts
-      - run:
           name: clone clients
           command: |
             for client in wnyc wqxr new-sounds wnyc-studios; do

--- a/circle.yml
+++ b/circle.yml
@@ -68,6 +68,9 @@ jobs:
       - image: circleci/buildpack-deps:jessie
     working_directory: ~
     steps:
+      - add_ssh_keys:
+          fingerprints:
+            - "46:1b:e7:bf:91:16:06:e2:79:99:fd:3d:00:c1:28:0a"
       - run:
           name: clone clients
           command: |
@@ -90,9 +93,6 @@ jobs:
 
     steps:
       - checkout
-      - add_ssh_keys:
-          fingerprints:
-            - "46:1b:e7:bf:91:16:06:e2:79:99:fd:3d:00:c1:28:0a"
       - store_test_results:
           path: wnyc-test-results/
       - restore_cache:

--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@ version: 2
 
 jobs:
   install:
-    >>: *defaults
+    <<: *defaults
     working_directory: /home/circleci/nypr-ui
     steps:
       - checkout
@@ -36,7 +36,7 @@ jobs:
             - nypr-ui
 
   test:
-    >>: *defaults
+    <<: *defaults
     working_directory: /home/circleci/nypr-ui
 
     steps:
@@ -91,66 +91,66 @@ jobs:
             - wnyc-studios-web-client
 
   test_wnyc:
-    >>: *defaults
+    <<: *defaults
     working_directory: /home/circleci/wnyc-web-client
     environment:
       CIRCLE_TEST_REPORTS: wnyc-test-results
 
     steps:
-      >>: *link_nypr_ui
-      >>: *client_install_node
-      >>: *client_install_bower
-      >>: *client_build_modernizr
+      <<: *link_nypr_ui
+      <<: *client_install_node
+      <<: *client_install_bower
+      <<: *client_build_modernizr
 
-      >>: *client_test_steps
+      <<: *client_test_steps
 
       - store_test_results:
           path: wnyc-test-results/
 
 
   test_wqxr:
-    >>: *defaults
+    <<: *defaults
     working_directory: /home/circleci/wqxr-web-client
     environment:
       CIRCLE_TEST_REPORTS: wqxr-test-results
 
     steps:
-      >>: *link_nypr_ui
-      >>: *client_install_node
-      >>: *client_install_bower
-      >>: *client_build_modernizr
+      <<: *link_nypr_ui
+      <<: *client_install_node
+      <<: *client_install_bower
+      <<: *client_build_modernizr
 
-      >>: *client_test_steps
+      <<: *client_test_steps
 
       - store_test_results:
           path: wqxr-test-results/
 
   test_new_sounds:
-    >>: *defaults
+    <<: *defaults
     working_directory: /home/circleci/new-sounds-web-client
     environment:
       CIRCLE_TEST_REPORTS: new-sounds-test-results
 
     steps:
-      >>: *link_nypr_ui
-      >>: *client_install_node
+      <<: *link_nypr_ui
+      <<: *client_install_node
 
-      >>: *client_test_steps
+      <<: *client_test_steps
 
       - store_test_results:
           path: new-sounds-test-results/
 
   test_wnyc_studios_ember:
-    >>: *defaults
+    <<: *defaults
     parallelism: 4
     working_directory: /home/circleci/wnyc-studios-web-client
     environment:
       CIRCLE_TEST_REPORTS: wnyc-studios-test-results
 
     steps:
-      >>: *link_nypr_ui
-      >>: *client_install_node
-      >>: *client_build_modernizr
+      <<: *link_nypr_ui
+      <<: *client_install_node
+      <<: *client_build_modernizr
 
       - run: |
           cp .env.sample .env
@@ -160,16 +160,16 @@ jobs:
           path: wnyc-studios-test-results/
 
   test_wnyc_studios_cypress:
-    >>: *defaults
+    <<: *defaults
     parallelism: 4
     working_directory: /home/circleci/wnyc-studios-web-client
     environment:
       CIRCLE_TEST_REPORTS: wnyc-studios-test-results
 
     steps:
-      >>: *link_nypr_ui
-      >>: *client_install_node
-      >>: *client_build_modernizr
+      <<: *link_nypr_ui
+      <<: *client_install_node
+      <<: *client_build_modernizr
 
       - run: |
           cp .env.sample .env
@@ -181,7 +181,7 @@ jobs:
 
 
   deploy:
-    >>: *defaults
+    <<: *defaults
     working_directory: /home/circleci/nypr-ui
     steps:
       - attach_workspace:
@@ -249,20 +249,20 @@ workflows:
             branches:
               only: master
 
-&container_defaults: *defaults
+container_defaults: &defaults
   docker:
     - image: circleci/node:8.7-browsers
       environment:
         JOBS: 2
 
-&link_nypr_ui: *link_nypr_ui
+link_nypr_ui: &link_nypr_ui
   - attach_workspace:
       at: /home/circleci
   - run:
       name: make global symlink
       command: cd /home/circleci/nypr-ui && yarn link
 
-&client_install_node: *client_install_node
+client_install_node: &client_install_node
   - restore_cache:
       key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
   - run:
@@ -276,7 +276,7 @@ workflows:
       paths:
         - node_modules
 
-&client_install_bower: *client_install_bower
+client_install_bower: &client_install_bower
   - restore_cache:
       key: bower-deps-{{ checksum "bower.json" }}
   - run:
@@ -287,12 +287,12 @@ workflows:
       paths:
         - bower_components
 
-&client_build_modernizr: *client_build_modernizr
+client_build_modernizr: &client_build_modernizr
   - run:
       name: Build modernizr
       command: npx grunt modernizr:dist
 
-&client_test_steps: *client_test_steps
+client_test_steps: &client_test_steps
   - run:
       name: link and test
       environment:

--- a/circle.yml
+++ b/circle.yml
@@ -93,6 +93,7 @@ jobs:
         environment:
           JOBS: 2
 
+    working_directory: ~
     steps:
       - checkout
       - restore_cache:
@@ -101,7 +102,7 @@ jobs:
           key: bower-deps-{{ checksum "bower.json" }}
 
       - attach_workspace:
-          at: $HOME
+          at: .
 
       - restore_cache:
           key: bower-deps-{{ checksum "~/wnyc-web-client/bower.json" }}

--- a/circle.yml
+++ b/circle.yml
@@ -93,7 +93,6 @@ jobs:
         environment:
           JOBS: 2
 
-    working_directory: ~
     steps:
       - checkout
       - restore_cache:
@@ -102,7 +101,7 @@ jobs:
           key: bower-deps-{{ checksum "bower.json" }}
 
       - attach_workspace:
-          at: .
+          at: /home/circleci
 
       - restore_cache:
           key: bower-deps-{{ checksum "~/wnyc-web-client/bower.json" }}

--- a/circle.yml
+++ b/circle.yml
@@ -1,62 +1,8 @@
 version: 2
 
-container_defaults: &defaults
-  docker:
-    - image: circleci/node:8.7-browsers
-      environment:
-        JOBS: 2
-
-link_nypr_ui: &link_nypr_ui
-  - attach_workspace:
-      at: /home/circleci
-  - run:
-      name: make global symlink
-      command: cd /home/circleci/nypr-ui && yarn link
-
-client_install_node: &client_install_node
-  - restore_cache:
-      key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
-  - run:
-      name: node deps
-      command: |
-        if [ ! -d node_modules ]; then
-          yarn --pure-lockfile
-        fi
-  - save_cache:
-      key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
-      paths:
-        - node_modules
-
-client_install_bower: &client_install_bower
-  - restore_cache:
-      key: bower-deps-{{ checksum "bower.json" }}
-  - run:
-      name: bower deps
-      command: npx bower i
-  - save_cache:
-      key: bower-deps-{{ checksum "bower.json" }}
-      paths:
-        - bower_components
-
-client_build_modernizr: &client_build_modernizr
-  - run:
-      name: Build modernizr
-      command: npx grunt modernizr:dist
-
-client_test_steps: &client_test_steps
-  - run:
-      name: link and test
-      environment:
-      command: |
-        yarn link nypr-ui
-        npx ember test
-
 jobs:
   install:
-    docker:
-      - image: circleci/node:8.7-browsers
-        environment:
-          JOBS: 2
+    <<: *defaults
     working_directory: /home/circleci/nypr-ui
     steps:
       - checkout
@@ -151,12 +97,45 @@ jobs:
       CIRCLE_TEST_REPORTS: wnyc-test-results
 
     steps:
-      - <<: *link_nypr_ui
-      - <<: *client_install_node
-      - <<: *client_install_bower
-      - <<: *client_build_modernizr
+      - attach_workspace:
+          at: /home/circleci
+      - run:
+          name: make global symlink
+          command: cd /home/circleci/nypr-ui && yarn link
 
-      - <<: *client_test_steps
+      - restore_cache:
+          key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
+      - run:
+          name: node deps
+          command: |
+            if [ ! -d node_modules ]; then
+              yarn --pure-lockfile
+            fi
+      - save_cache:
+          key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
+          paths:
+            - node_modules
+
+      - restore_cache:
+          key: bower-deps-{{ checksum "bower.json" }}
+      - run:
+          name: bower deps
+          command: npx bower i
+      - save_cache:
+          key: bower-deps-{{ checksum "bower.json" }}
+          paths:
+            - bower_components
+
+      - run:
+          name: Build modernizr
+          command: npx grunt modernizr:dist || true
+
+      - run:
+          name: link and test
+          environment:
+          command: |
+            yarn link nypr-ui
+            npx ember test
 
       - store_test_results:
           path: wnyc-test-results/
@@ -169,12 +148,45 @@ jobs:
       CIRCLE_TEST_REPORTS: wqxr-test-results
 
     steps:
-      - <<: *link_nypr_ui
-      - <<: *client_install_node
-      - <<: *client_install_bower
-      - <<: *client_build_modernizr
+      - attach_workspace:
+          at: /home/circleci
+      - run:
+          name: make global symlink
+          command: cd /home/circleci/nypr-ui && yarn link
 
-      - <<: *client_test_steps
+      - restore_cache:
+          key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
+      - run:
+          name: node deps
+          command: |
+            if [ ! -d node_modules ]; then
+              yarn --pure-lockfile
+            fi
+      - save_cache:
+          key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
+          paths:
+            - node_modules
+
+      - restore_cache:
+          key: bower-deps-{{ checksum "bower.json" }}
+      - run:
+          name: bower deps
+          command: npx bower i
+      - save_cache:
+          key: bower-deps-{{ checksum "bower.json" }}
+          paths:
+            - bower_components
+
+      - run:
+          name: Build modernizr
+          command: npx grunt modernizr:dist
+
+      - run:
+          name: link and test
+          environment:
+          command: |
+            yarn link nypr-ui
+            npx ember test
 
       - store_test_results:
           path: wqxr-test-results/
@@ -186,10 +198,31 @@ jobs:
       CIRCLE_TEST_REPORTS: new-sounds-test-results
 
     steps:
-      - <<: *link_nypr_ui
-      - <<: *client_install_node
+      - attach_workspace:
+          at: /home/circleci
+      - run:
+          name: make global symlink
+          command: cd /home/circleci/nypr-ui && yarn link
 
-      - <<: *client_test_steps
+      - restore_cache:
+          key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
+      - run:
+          name: node deps
+          command: |
+            if [ ! -d node_modules ]; then
+              yarn --pure-lockfile
+            fi
+      - save_cache:
+          key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
+          paths:
+            - node_modules
+
+      - run:
+          name: link and test
+          environment:
+          command: |
+            yarn link nypr-ui
+            npx ember test
 
       - store_test_results:
           path: new-sounds-test-results/
@@ -202,9 +235,28 @@ jobs:
       CIRCLE_TEST_REPORTS: wnyc-studios-test-results
 
     steps:
-      - <<: *link_nypr_ui
-      - <<: *client_install_node
-      - <<: *client_build_modernizr
+      - attach_workspace:
+          at: /home/circleci
+      - run:
+          name: make global symlink
+          command: cd /home/circleci/nypr-ui && yarn link
+
+      - restore_cache:
+          key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
+      - run:
+          name: node deps
+          command: |
+            if [ ! -d node_modules ]; then
+              yarn --pure-lockfile
+            fi
+      - save_cache:
+          key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
+          paths:
+            - node_modules
+
+      - run:
+          name: Build modernizr
+          command: npx grunt modernizr:dist
 
       - run: |
           cp .env.sample .env
@@ -221,9 +273,28 @@ jobs:
       CIRCLE_TEST_REPORTS: wnyc-studios-test-results
 
     steps:
-      - <<: *link_nypr_ui
-      - <<: *client_install_node
-      - <<: *client_build_modernizr
+      - attach_workspace:
+          at: /home/circleci
+      - run:
+          name: make global symlink
+          command: cd /home/circleci/nypr-ui && yarn link
+
+      - restore_cache:
+          key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
+      - run:
+          name: node deps
+          command: |
+            if [ ! -d node_modules ]; then
+              yarn --pure-lockfile
+            fi
+      - save_cache:
+          key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
+          paths:
+            - node_modules
+
+      - run:
+          name: Build modernizr
+          command: npx grunt modernizr:dist
 
       - run: |
           cp .env.sample .env
@@ -302,3 +373,9 @@ workflows:
           filters:
             branches:
               only: master
+
+container_defaults: &defaults
+  docker:
+    - image: circleci/node:8.7-browsers
+      environment:
+        JOBS: 2

--- a/circle.yml
+++ b/circle.yml
@@ -72,6 +72,9 @@ jobs:
           fingerprints:
             - "46:1b:e7:bf:91:16:06:e2:79:99:fd:3d:00:c1:28:0a"
       - run:
+          name: Keyscan Github
+          command: ssh-keyscan -H github.com >> ~/.ssh/known_hosts
+      - run:
           name: clone clients
           command: |
             for client in wnyc wqxr new-sounds wnyc-studios; do

--- a/circle.yml
+++ b/circle.yml
@@ -68,10 +68,6 @@ jobs:
       - image: circleci/buildpack-deps:jessie
     working_directory: ~
     steps:
-      - add_ssh_keys:
-          fingerprints:
-            - "c5:68:42:20:05:ba:99:2f:9f:07:22:46:30:71:ca:a1" # for studios
-            - "8b:44:88:9d:98:b1:2e:01:c9:95:40:1d:3e:45:ed:42" # for new sounds
       - run:
           name: Keyscan Github
           command: ssh-keyscan -H github.com >> ~/.ssh/known_hosts

--- a/circle.yml
+++ b/circle.yml
@@ -95,8 +95,6 @@ jobs:
 
     steps:
       - checkout
-      - store_test_results:
-          path: wnyc-test-results/
       - restore_cache:
           key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
       - restore_cache:
@@ -143,6 +141,8 @@ jobs:
           command: |
             yarn link nypr-ui
             npx ember test
+      - store_test_results:
+          path: wnyc-test-results/
 
 
   test_wqxr:

--- a/circle.yml
+++ b/circle.yml
@@ -70,7 +70,6 @@ jobs:
     steps:
       - add_ssh_keys:
           fingerprints:
-            - "46:1b:e7:bf:91:16:06:e2:79:99:fd:3d:00:c1:28:0a"
             - "8b:44:88:9d:98:b1:2e:01:c9:95:40:1d:3e:45:ed:42" # for new sounds
       - run:
           name: Keyscan Github

--- a/circle.yml
+++ b/circle.yml
@@ -27,9 +27,6 @@ jobs:
           key: bower-deps-{{ checksum "bower.json" }}
           paths:
             - ./bower_components
-      - run:
-          name: make global symlink
-          command: yarn link
 
   test:
     docker:
@@ -99,6 +96,9 @@ jobs:
           key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
       - restore_cache:
           key: bower-deps-{{ checksum "bower.json" }}
+      - run:
+          name: make global symlink
+          command: yarn link
 
       - attach_workspace:
           at: /home/circleci

--- a/circle.yml
+++ b/circle.yml
@@ -71,6 +71,7 @@ jobs:
       - add_ssh_keys:
           fingerprints:
             - "46:1b:e7:bf:91:16:06:e2:79:99:fd:3d:00:c1:28:0a"
+            - "8b:44:88:9d:98:b1:2e:01:c9:95:40:1d:3e:45:ed:42" # for new sounds
       - run:
           name: Keyscan Github
           command: ssh-keyscan -H github.com >> ~/.ssh/known_hosts

--- a/circle.yml
+++ b/circle.yml
@@ -212,8 +212,8 @@ jobs:
           paths:
             - node_modules
 
-        - run:
-            name: link and test
+      - run:
+          name: link and test
           environment:
             CIRCLE_TEST_REPORTS: new-sounds-test-results
           command: |

--- a/circle.yml
+++ b/circle.yml
@@ -71,7 +71,7 @@ jobs:
       - run:
           name: Keyscan Github
           command: |
-            md ~/.ssh
+            mkdir ~/.ssh
             ssh-keyscan -H github.com >> ~/.ssh/known_hosts
       - run:
           name: clone clients

--- a/circle.yml
+++ b/circle.yml
@@ -88,6 +88,7 @@ jobs:
             - wqxr-web-client
             - new-sounds-web-client
             - wnyc-studios-web-client
+            - nypr-ui
 
   test_wnyc:
     working_directory: /home/circleci/wnyc-web-client
@@ -100,17 +101,16 @@ jobs:
           JOBS: 2
 
     steps:
-      - checkout
-      - restore_cache:
-          key: nypr-ui-yarn-deps-{{ arch }}-{{ checksum "/home/circleci/nypr-ui/yarn.lock" }}
-      - restore_cache:
-          key: nypr-ui-bower-deps-{{ checksum "/home/circleci/nypr-ui/bower.json" }}
+      - attach_workspace:
+          at: /home/circleci
+
+#      - restore_cache:
+#          key: nypr-ui-yarn-deps-{{ arch }}-{{ checksum "/home/circleci/nypr-ui/yarn.lock" }}
+#      - restore_cache:
+#          key: nypr-ui-bower-deps-{{ checksum "/home/circleci/nypr-ui/bower.json" }}
       - run:
           name: make global symlink
           command: cd /home/circleci/nypr-ui && yarn link
-
-      - attach_workspace:
-          at: /home/circleci
 
       - restore_cache:
           key: bower-deps-{{ checksum "bower.json" }}

--- a/circle.yml
+++ b/circle.yml
@@ -1,5 +1,56 @@
 version: 2
 
+container_defaults: &defaults
+  docker:
+    - image: circleci/node:8.7-browsers
+      environment:
+        JOBS: 2
+
+link_nypr_ui: &link_nypr_ui
+  - attach_workspace:
+      at: /home/circleci
+  - run:
+      name: make global symlink
+      command: cd /home/circleci/nypr-ui && yarn link
+
+client_install_node: &client_install_node
+  - restore_cache:
+      key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
+  - run:
+      name: node deps
+      command: |
+        if [ ! -d node_modules ]; then
+          yarn --pure-lockfile
+        fi
+  - save_cache:
+      key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
+      paths:
+        - node_modules
+
+client_install_bower: &client_install_bower
+  - restore_cache:
+      key: bower-deps-{{ checksum "bower.json" }}
+  - run:
+      name: bower deps
+      command: npx bower i
+  - save_cache:
+      key: bower-deps-{{ checksum "bower.json" }}
+      paths:
+        - bower_components
+
+client_build_modernizr: &client_build_modernizr
+  - run:
+      name: Build modernizr
+      command: npx grunt modernizr:dist
+
+client_test_steps: &client_test_steps
+  - run:
+      name: link and test
+      environment:
+      command: |
+        yarn link nypr-ui
+        npx ember test
+
 jobs:
   install:
     <<: *defaults
@@ -248,54 +299,3 @@ workflows:
           filters:
             branches:
               only: master
-
-container_defaults: &defaults
-  docker:
-    - image: circleci/node:8.7-browsers
-      environment:
-        JOBS: 2
-
-link_nypr_ui: &link_nypr_ui
-  - attach_workspace:
-      at: /home/circleci
-  - run:
-      name: make global symlink
-      command: cd /home/circleci/nypr-ui && yarn link
-
-client_install_node: &client_install_node
-  - restore_cache:
-      key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
-  - run:
-      name: node deps
-      command: |
-        if [ ! -d node_modules ]; then
-          yarn --pure-lockfile
-        fi
-  - save_cache:
-      key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
-      paths:
-        - node_modules
-
-client_install_bower: &client_install_bower
-  - restore_cache:
-      key: bower-deps-{{ checksum "bower.json" }}
-  - run:
-      name: bower deps
-      command: npx bower i
-  - save_cache:
-      key: bower-deps-{{ checksum "bower.json" }}
-      paths:
-        - bower_components
-
-client_build_modernizr: &client_build_modernizr
-  - run:
-      name: Build modernizr
-      command: npx grunt modernizr:dist
-
-client_test_steps: &client_test_steps
-  - run:
-      name: link and test
-      environment:
-      command: |
-        yarn link nypr-ui
-        npx ember test

--- a/circle.yml
+++ b/circle.yml
@@ -31,6 +31,11 @@ jobs:
           paths:
             - bower_components
 
+      - persist_to_workspace:
+          root: .
+          paths:
+            - .
+
   test:
     working_directory: /home/circleci/nypr-ui
     environment:
@@ -88,7 +93,6 @@ jobs:
             - wqxr-web-client
             - new-sounds-web-client
             - wnyc-studios-web-client
-            - nypr-ui
 
   test_wnyc:
     working_directory: /home/circleci/wnyc-web-client

--- a/circle.yml
+++ b/circle.yml
@@ -69,6 +69,11 @@ jobs:
     working_directory: ~
     steps:
       - run:
+          name: Keyscan Github
+          command: |
+            md ~/.ssh
+            ssh-keyscan -H github.com >> ~/.ssh/known_hosts
+      - run:
           name: clone clients
           command: |
             for client in wnyc wqxr new-sounds wnyc-studios; do

--- a/circle.yml
+++ b/circle.yml
@@ -71,6 +71,11 @@ jobs:
     working_directory: /home/circleci
     steps:
       - run:
+          name: Keyscan Github
+          command: |
+            mkdir ~/.ssh
+            ssh-keyscan -H github.com >> ~/.ssh/known_hosts
+      - run:
           name: clone clients
           command: |
             for client in wnyc wqxr new-sounds wnyc-studios; do

--- a/circle.yml
+++ b/circle.yml
@@ -94,10 +94,12 @@ jobs:
       - <<: *restore_node
       - <<: *restore_bower
 
-      - run: yarn global add greenkeeper-lockfile@1
-      - run: npx greenkeeper-lockfile-update
-      - run: npx ember test
-      - run: npx greenkeeper-lockfile-upload
+      - run: |
+          yarn global add greenkeeper-lockfile@1
+          npx greenkeeper-lockfile-update
+          npx ember test
+          npx greenkeeper-lockfile-upload
+
       - store_test_results:
           path: test-results/
 

--- a/circle.yml
+++ b/circle.yml
@@ -2,9 +2,8 @@ version: 2
 
 jobs:
   install:
+    >>: *defaults
     working_directory: /home/circleci/nypr-ui
-    docker:
-      - image: circleci/node:8.7
     steps:
       - checkout
 
@@ -37,11 +36,8 @@ jobs:
             - nypr-ui
 
   test:
+    >>: *defaults
     working_directory: /home/circleci/nypr-ui
-    environment:
-      JOBS: 2
-    docker:
-      - image: circleci/node:8.7-browsers
 
     steps:
       - checkout
@@ -95,240 +91,101 @@ jobs:
             - wnyc-studios-web-client
 
   test_wnyc:
+    >>: *defaults
     working_directory: /home/circleci/wnyc-web-client
     environment:
       CIRCLE_TEST_REPORTS: wnyc-test-results
 
-    docker:
-      - image: circleci/node:8.7-browsers
-        environment:
-          JOBS: 2
-
     steps:
-      - attach_workspace:
-          at: /home/circleci
+      >>: *link_nypr_ui
+      >>: *client_install_node
+      >>: *client_install_bower
+      >>: *client_build_modernizr
 
-#      - restore_cache:
-#          key: nypr-ui-yarn-deps-{{ arch }}-{{ checksum "/home/circleci/nypr-ui/yarn.lock" }}
-#      - restore_cache:
-#          key: nypr-ui-bower-deps-{{ checksum "/home/circleci/nypr-ui/bower.json" }}
-      - run:
-          name: make global symlink
-          command: cd /home/circleci/nypr-ui && yarn link
-
-      - restore_cache:
-          key: bower-deps-{{ checksum "bower.json" }}
-      - run:
-          name: bower deps
-          command: npx bower i
-      - save_cache:
-          key: bower-deps-{{ checksum "bower.json" }}
-          paths:
-            - bower_components
-
-      - restore_cache:
-          key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
-      - run:
-          name: node deps
-          command: |
-            if [ ! -d node_modules ]; then
-              yarn --pure-lockfile
-            fi
-      - save_cache:
-          key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
-          paths:
-            - node_modules
-
-      - run:
-          name: Build modernizr
-          command: npx grunt modernizr:dist
-
-      - run:
-          name: link and test
-          environment:
-          command: |
-            yarn link nypr-ui
-            npx ember test
+      >>: *client_test_steps
 
       - store_test_results:
           path: wnyc-test-results/
 
 
   test_wqxr:
-    docker:
-      - image: circleci/node:8.7-browsers
-        environment:
-          JOBS: 2
+    >>: *defaults
+    working_directory: /home/circleci/wqxr-web-client
+    environment:
+      CIRCLE_TEST_REPORTS: wqxr-test-results
 
     steps:
-      - checkout
-      - add_ssh_keys:
-          fingerprints:
-            - "46:1b:e7:bf:91:16:06:e2:79:99:fd:3d:00:c1:28:0a"
+      >>: *link_nypr_ui
+      >>: *client_install_node
+      >>: *client_install_bower
+      >>: *client_build_modernizr
+
+      >>: *client_test_steps
+
       - store_test_results:
           path: wqxr-test-results/
-      - restore_cache:
-          key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
-      - restore_cache:
-          key: bower-deps-{{ checksum "bower.json" }}
-
-      - run:
-          name: clone wqxr
-          command: |
-            cd ~
-            git clone git@github.com:nypublicradio/wqxr-web-client
-            cd ~/wqxr-web-client
-
-      - restore_cache:
-          key: bower-deps-{{ checksum "bower.json" }}
-      - run:
-          name: wqxr bower deps
-          command: npx bower i
-      - save_cache:
-          key: bower-deps-{{ checksum "bower.json" }}
-          paths:
-            - bower_components
-
-      - restore_cache:
-          key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
-      - run:
-          name: wqxr node deps
-          command: |
-            if [ ! -d ./node_modules ]; then
-              yarn --pure-lockfile
-            fi
-      - save_cache:
-          key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
-          paths:
-            - node_modules
-
-      - run:
-          name: Build modernizr
-          command: npx grunt modernizr:dist
-
-      - run:
-          name: link and test
-          environment:
-            CIRCLE_TEST_REPORTS: wqxr-test-results
-          command: |
-            yarn link nypr-ui
-            npx ember test
 
   test_new_sounds:
-    docker:
-      - image: circleci/node:8.7-browsers
-        environment:
-          JOBS: 2
+    >>: *defaults
+    working_directory: /home/circleci/new-sounds-web-client
+    environment:
+      CIRCLE_TEST_REPORTS: new-sounds-test-results
 
     steps:
-      - checkout
-      - add_ssh_keys:
-          fingerprints:
-            - "46:1b:e7:bf:91:16:06:e2:79:99:fd:3d:00:c1:28:0a"
+      >>: *link_nypr_ui
+      >>: *client_install_node
+
+      >>: *client_test_steps
+
       - store_test_results:
           path: new-sounds-test-results/
-      - restore_cache:
-          key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
-      - restore_cache:
-          key: bower-deps-{{ checksum "bower.json" }}
-      - run:
-          name: clone new sounds
-          command: |
-            cd ~
-            git clone git@github.com:nypublicradio/new-sounds-web-client
-            cd ~/new-sounds-web-client
 
-      - restore_cache:
-          key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
-      - run:
-          name: new sounds node deps
-          command: |
-            if [ ! -d ./node_modules ]; then
-              yarn --pure-lockfile
-            fi
-      - save_cache:
-          key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
-          paths:
-            - node_modules
-
-      - run:
-          name: link and test
-          environment:
-            CIRCLE_TEST_REPORTS: new-sounds-test-results
-          command: |
-            yarn link nypr-ui
-            npx ember test
-
-  test_wnyc_studios:
+  test_wnyc_studios_ember:
+    >>: *defaults
     parallelism: 4
-    docker:
-      - image: circleci/node:8.7-browsers
-        environment:
-          JOBS: 2
+    working_directory: /home/circleci/wnyc-studios-web-client
+    environment:
+      CIRCLE_TEST_REPORTS: wnyc-studios-test-results
 
     steps:
-      - checkout
-      - add_ssh_keys:
-          fingerprints:
-            - "46:1b:e7:bf:91:16:06:e2:79:99:fd:3d:00:c1:28:0a"
+      >>: *link_nypr_ui
+      >>: *client_install_node
+      >>: *client_build_modernizr
+
+      - run: |
+          cp .env.sample .env
+          npx ember exam --split=$CIRCLE_NODE_TOTAL --partition=$(($CIRCLE_NODE_INDEX + 1))
+
       - store_test_results:
           path: wnyc-studios-test-results/
-      - restore_cache:
-          key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
-      - restore_cache:
-          key: bower-deps-{{ checksum "bower.json" }}
 
-      - run:
-          name: clone wnyc studios
-          command: |
-            cd ~
-            git clone git@github.com:nypublicradio/wnyc-studios-web-client
-            cd ~/wnyc-studios-web-client
+  test_wnyc_studios_cypress:
+    >>: *defaults
+    parallelism: 4
+    working_directory: /home/circleci/wnyc-studios-web-client
+    environment:
+      CIRCLE_TEST_REPORTS: wnyc-studios-test-results
 
-      - restore_cache:
-          key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
-      - run:
-          name: wqxr node deps
-          command: |
-            if [ ! -d ./node_modules ]; then
-              yarn --pure-lockfile
-            fi
-      - save_cache:
-          key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
-          paths:
-            - node_modules
+    steps:
+      >>: *link_nypr_ui
+      >>: *client_install_node
+      >>: *client_build_modernizr
 
-      - run:
-          name: Build modernizr
-          command: npx grunt modernizr:dist
+      - run: |
+          cp .env.sample .env
+          sudo apt-get install libgconf-2-4
+          yarn run cy:ci:test
 
-      - run:
-          name: link and test
-          environment:
-            CIRCLE_TEST_REPORTS: wnyc-studios-test-results
-          command: |
-            yarn link nypr-ui
-            npx ember exam --split=$CIRCLE_NODE_TOTAL --partition=$(($CIRCLE_NODE_INDEX + 1))
-            sudo apt-get install libgconf-2-4
-            cp .env.sample .env
-            yarn run cy:ci:test
+      - store_test_results:
+          path: wnyc-studios-test-results/
 
 
   deploy:
+    >>: *defaults
     working_directory: /home/circleci/nypr-ui
-    environment:
-      JOBS: 2
-    docker:
-      - image: circleci/node:8.7
     steps:
-      - checkout
-      - restore_cache:
-          key: nypr-ui-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
-      - restore_cache:
-          key: nypr-ui-bower-deps-{{ checksum "bower.json" }}
-      - add_ssh_keys:
-          fingerprints:
-            - "46:1b:e7:bf:91:16:06:e2:79:99:fd:3d:00:c1:28:0a"
+      - attach_workspace:
+          at: /home/circleci
       - run:
          name: Deploy to GitHub Pages
          command: |
@@ -384,3 +241,54 @@ workflows:
           filters:
             branches:
               only: master
+
+&container_defaults: *defaults
+  docker:
+    - image: circleci/node:8.7-browsers
+      environment:
+        JOBS: 2
+
+&link_nypr_ui: *link_nypr_ui
+  - attach_workspace:
+      at: /home/circleci
+  - run:
+      name: make global symlink
+      command: cd /home/circleci/nypr-ui && yarn link
+
+&client_install_node: *client_install_node
+  - restore_cache:
+      key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
+  - run:
+      name: node deps
+      command: |
+        if [ ! -d node_modules ]; then
+          yarn --pure-lockfile
+        fi
+  - save_cache:
+      key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
+      paths:
+        - node_modules
+
+&client_install_bower: *client_install_bower
+  - restore_cache:
+      key: bower-deps-{{ checksum "bower.json" }}
+  - run:
+      name: bower deps
+      command: npx bower i
+  - save_cache:
+      key: bower-deps-{{ checksum "bower.json" }}
+      paths:
+        - bower_components
+
+&client_build_modernizr: *client_build_modernizr
+  - run:
+      name: Build modernizr
+      command: npx grunt modernizr:dist
+
+&client_test_steps: *client_test_steps
+  - run:
+      name: link and test
+      environment:
+      command: |
+        yarn link nypr-ui
+        npx ember test

--- a/circle.yml
+++ b/circle.yml
@@ -71,6 +71,9 @@ jobs:
 
     steps:
       - checkout
+      - add_ssh_keys:
+          fingerprints:
+            - "46:1b:e7:bf:91:16:06:e2:79:99:fd:3d:00:c1:28:0a"
       - store_test_results:
           path: wnyc-test-results/
       - restore_cache:
@@ -129,6 +132,9 @@ jobs:
 
     steps:
       - checkout
+      - add_ssh_keys:
+          fingerprints:
+            - "46:1b:e7:bf:91:16:06:e2:79:99:fd:3d:00:c1:28:0a"
       - store_test_results:
           path: wqxr-test-results/
       - restore_cache:
@@ -186,6 +192,9 @@ jobs:
 
     steps:
       - checkout
+      - add_ssh_keys:
+          fingerprints:
+            - "46:1b:e7:bf:91:16:06:e2:79:99:fd:3d:00:c1:28:0a"
       - store_test_results:
           path: new-sounds-test-results/
       - restore_cache:
@@ -229,6 +238,9 @@ jobs:
 
     steps:
       - checkout
+      - add_ssh_keys:
+          fingerprints:
+            - "46:1b:e7:bf:91:16:06:e2:79:99:fd:3d:00:c1:28:0a"
       - store_test_results:
           path: wnyc-studios-test-results/
       - restore_cache:

--- a/circle.yml
+++ b/circle.yml
@@ -32,9 +32,9 @@ jobs:
             - bower_components
 
       - persist_to_workspace:
-          root: .
+          root: /home/circleci
           paths:
-            - .
+            - nypr-ui
 
   test:
     working_directory: /home/circleci/nypr-ui

--- a/circle.yml
+++ b/circle.yml
@@ -154,7 +154,6 @@ jobs:
       - store_test_results:
           path: wnyc-test-results/
 
-
   test_wqxr:
     <<: *defaults
     working_directory: /home/circleci/wqxr-web-client
@@ -248,7 +247,6 @@ jobs:
       - store_test_results:
           path: wnyc-studios-test-results/
 
-
   deploy:
     <<: *defaults
     working_directory: /home/circleci/nypr-ui
@@ -263,12 +261,21 @@ jobs:
 
 workflows:
   version: 2
+  just-test:
+    jobs:
+      - install
+      - test:
+          requires:
+            - install
   test-and-deploy:
     jobs:
       - install
       - test:
           requires:
             - install
+          filters:
+            branches:
+              only: qa-build
       - setup_test_clients:
           requires:
             - install

--- a/circle.yml
+++ b/circle.yml
@@ -101,7 +101,7 @@ jobs:
           key: bower-deps-{{ checksum "bower.json" }}
 
       - attach_workspace:
-          at: ~/wnyc-web-client
+          at: $HOME
 
       - restore_cache:
           key: bower-deps-{{ checksum "~/wnyc-web-client/bower.json" }}

--- a/circle.yml
+++ b/circle.yml
@@ -83,40 +83,42 @@ jobs:
 
       - run:
           name: clone wnyc
-          command: |
-            cd ~
-            git clone git@github.com:nypublicradio/wnyc-web-client
-            cd ~/wnyc-web-client
+          working_directory: ~
+          command: git clone git@github.com:nypublicradio/wnyc-web-client
 
       - restore_cache:
-          key: bower-deps-{{ checksum "bower.json" }}
+          key: bower-deps-{{ checksum "~/wnyc-web-client/bower.json" }}
       - run:
           name: wnyc bower deps
+          working_directory: ~/wnyc-web-client
           command: npx bower i
       - save_cache:
-          key: bower-deps-{{ checksum "bower.json" }}
+          key: bower-deps-{{ checksum "~/wnyc-web-client/bower.json" }}
           paths:
             - bower_components
 
       - restore_cache:
-          key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
+          key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "~/wnyc-web-client/yarn.lock" }}
       - run:
           name: wnyc node deps
+          working_directory: ~/wnyc-web-client
           command: |
             if [ ! -d ./node_modules ]; then
               yarn --pure-lockfile
             fi
       - save_cache:
-          key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
+          key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "~/wnyc-web-client/yarn.lock" }}
           paths:
-            - node_modules
+            - ~/wnyc-web-client/node_modules
 
       - run:
           name: Build modernizr
           command: npx grunt modernizr:dist
+          working_directory: ~/wnyc-web-client
 
       - run:
           name: link and test
+          working_directory: ~/wnyc-web-client
           environment:
             CIRCLE_TEST_REPORTS: wnyc-test-results
           command: |

--- a/circle.yml
+++ b/circle.yml
@@ -269,7 +269,7 @@ workflows:
             - install
   test-and-deploy:
     jobs:
-      - install
+      - install:
           filters:
             branches:
               only: master

--- a/circle.yml
+++ b/circle.yml
@@ -95,10 +95,10 @@ jobs:
       - <<: *restore_bower
 
       - run: |
-          yarn global add greenkeeper-lockfile@1
-          npx greenkeeper-lockfile-update
+          sudo yarn global add greenkeeper-lockfile@1
+          greenkeeper-lockfile-update
           npx ember test
-          npx greenkeeper-lockfile-upload
+          greenkeeper-lockfile-upload
 
       - store_test_results:
           path: test-results/

--- a/circle.yml
+++ b/circle.yml
@@ -270,48 +270,30 @@ workflows:
   test-and-deploy:
     jobs:
       - install
+          filters:
+            branches:
+              only: master
       - test:
           requires:
             - install
-          filters:
-            branches:
-              only: qa-build
       - setup_test_clients:
           requires:
             - install
-          filters:
-            branches:
-              only: qa-build
       - test_wnyc:
           requires:
             - setup_test_clients
-          filters:
-            branches:
-              only: qa-build
       - test_wqxr:
           requires:
             - setup_test_clients
-          filters:
-            branches:
-              only: qa-build
       - test_wnyc_studios_ember:
           requires:
             - setup_test_clients
-          filters:
-            branches:
-              only: qa-build
       - test_wnyc_studios_cypress:
           requires:
             - setup_test_clients
-          filters:
-            branches:
-              only: qa-build
       - test_new_sounds:
           requires:
             - setup_test_clients
-          filters:
-            branches:
-              only: qa-build
       - deploy:
           requires:
             - test
@@ -320,6 +302,3 @@ workflows:
             - test_wnyc_studios_ember
             - test_wnyc_studios_cypress
             - test_new_sounds
-          filters:
-            branches:
-              only: master

--- a/circle.yml
+++ b/circle.yml
@@ -2,10 +2,12 @@ version: 2
 
 jobs:
   install:
+    working_directory: /home/circleci/nypr-ui
     docker:
       - image: circleci/node:8.7
     steps:
       - checkout
+
       - restore_cache:
           key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
       - run:
@@ -18,6 +20,7 @@ jobs:
           key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
           paths:
             - ./node_modules
+
       - restore_cache:
           key: bower-deps-{{ checksum "bower.json" }}
       - run:
@@ -29,10 +32,11 @@ jobs:
             - ./bower_components
 
   test:
+    working_directory: /home/circleci/nypr-ui
+    environment:
+      JOBS: 2
     docker:
       - image: circleci/node:8.7-browsers
-        environment:
-          JOBS: 2
 
     steps:
       - checkout
@@ -63,7 +67,7 @@ jobs:
   setup_test_clients:
     docker:
       - image: circleci/buildpack-deps:jessie
-    working_directory: ~
+    working_directory: /home/circleci
     steps:
       - run:
           name: Keyscan Github
@@ -85,17 +89,22 @@ jobs:
             - wnyc-studios-web-client
 
   test_wnyc:
+    working_directory: /home/circleci/wnyc-web-client
+    environment:
+      CIRCLE_TEST_REPORTS: wnyc-test-results
+
     docker:
       - image: circleci/node:8.7-browsers
         environment:
           JOBS: 2
+          ADDON_DIR: /home/circleci/nypr-ui
 
     steps:
       - checkout
       - restore_cache:
-          key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
+          key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "$ADDON_DIR/yarn.lock" }}
       - restore_cache:
-          key: bower-deps-{{ checksum "bower.json" }}
+          key: bower-deps-{{ checksum "$ADDON_DIR/bower.json" }}
       - run:
           name: make global symlink
           command: yarn link
@@ -104,43 +113,39 @@ jobs:
           at: /home/circleci
 
       - restore_cache:
-          key: bower-deps-{{ checksum "~/wnyc-web-client/bower.json" }}
+          key: bower-deps-{{ checksum "bower.json" }}
       - run:
-          name: wnyc bower deps
-          working_directory: ~/wnyc-web-client
+          name: bower deps
           command: npx bower i
       - save_cache:
-          key: bower-deps-{{ checksum "~/wnyc-web-client/bower.json" }}
+          key: bower-deps-{{ checksum "bower.json" }}
           paths:
             - bower_components
 
       - restore_cache:
-          key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "~/wnyc-web-client/yarn.lock" }}
+          key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
       - run:
-          name: wnyc node deps
-          working_directory: ~/wnyc-web-client
+          name: node deps
           command: |
             if [ ! -d ./node_modules ]; then
               yarn --pure-lockfile
             fi
       - save_cache:
-          key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "~/wnyc-web-client/yarn.lock" }}
+          key: v2-node8-yarn-deps-{{ arch }}-{{ checksum "yarn.lock" }}
           paths:
-            - ~/wnyc-web-client/node_modules
+            - node_modules
 
       - run:
           name: Build modernizr
           command: npx grunt modernizr:dist
-          working_directory: ~/wnyc-web-client
 
       - run:
           name: link and test
-          working_directory: ~/wnyc-web-client
           environment:
-            CIRCLE_TEST_REPORTS: wnyc-test-results
           command: |
             yarn link nypr-ui
             npx ember test
+
       - store_test_results:
           path: wnyc-test-results/
 
@@ -306,10 +311,11 @@ jobs:
 
 
   deploy:
+    working_directory: /home/circleci/nypr-ui
+    environment:
+      JOBS: 2
     docker:
       - image: circleci/node:8.7
-        environment:
-          JOBS: 2
     steps:
       - checkout
       - restore_cache:

--- a/circle.yml
+++ b/circle.yml
@@ -63,6 +63,25 @@ jobs:
       - store_test_results:
           path: test-results/
 
+  setup_test_clients:
+    docker:
+      - image: circleci/buildpack-deps:jessie
+    working_directory: ~
+    steps:
+      - run:
+          name: clone clients
+          command: |
+            for client in "wnyc wqxr new-sounds wnyc-studios"; do
+              git clone git@github.com:nypublicradio/$client-web-client
+            done
+      - persist_to_workspace:
+          root: .
+          paths:
+            - wnyc-web-client
+            - wqxr-web-client
+            - new-sounds-web-client
+            - wnyc-studios-web-client
+
   test_wnyc:
     docker:
       - image: circleci/node:8.7-browsers
@@ -81,10 +100,8 @@ jobs:
       - restore_cache:
           key: bower-deps-{{ checksum "bower.json" }}
 
-      - run:
-          name: clone wnyc
-          working_directory: ~
-          command: git clone git@github.com:nypublicradio/wnyc-web-client
+      - attach_workspace:
+          at: ~
 
       - restore_cache:
           key: bower-deps-{{ checksum "~/wnyc-web-client/bower.json" }}
@@ -315,27 +332,33 @@ workflows:
       - test:
           requires:
             - install
-      - test_wnyc:
+      - setup_test_clients:
           requires:
             - install
+          filters:
+            branches:
+              only: qa-build
+      - test_wnyc:
+          requires:
+            - setup_test_clients
           filters:
             branches:
               only: qa-build
       - test_wqxr:
           requires:
-            - install
+            - setup_test_clients
           filters:
             branches:
               only: qa-build
       - test_wnyc_studios:
           requires:
-            - install
+            - setup_test_clients
           filters:
             branches:
               only: qa-build
       - test_new_sounds:
           requires:
-            - install
+            - setup_test_clients
           filters:
             branches:
               only: qa-build


### PR DESCRIPTION
This circle file patch adds a serious test suite to the repo.

The plan is that on commits to master, Circle will clone the wnyc, wqxr, new sounds, and wnyc studios web clients and run their test suites against this version of nypr-ui. 

~Unfortunately, YAML does not support destructuring arrays, so there is a lot of duplication in the `steps` section for each of the web client tests. I'm open to hearing other ways we can clean up this file. Each web client has a similar set of steps, but they're not all the same.~

Figured out a way to reduce all the duplication and migrated this pattern to the rest of the addons.