### PR TITLE
Kate/mt 75

### DIFF
--- a/addon/templates/components/nypr-brick-item.hbs
+++ b/addon/templates/components/nypr-brick-item.hbs
@@ -21,13 +21,13 @@
       {{or item.showTitle item.channelTitle}}
     </a>
     <h2 class="item__head__headline">
-      {{#link-to
-        'story'
-        item.slug
-        data-label=(concat item.title " | " (or item.showTitle item.channelTitle 'NPR Article'))}}
-        {{nypr-svg className="icon" icon="video"}}
-        {{or item.shortTitle item.title}}
-      {{/link-to}}
+      <a
+        title={{or item.shortTitle item.title}}
+        data-label=(concat item.title " | " (or item.showTitle item.channelTitle 'NPR Article'))
+        href={{item.url}}>
+          {{nypr-svg className="icon" icon="video"}}
+          {{or item.shortTitle item.title}}
+      </a>
     </h2>
     {{#if item.audio}}
       {{#listen-button

--- a/addon/templates/components/nypr-brick-item.hbs
+++ b/addon/templates/components/nypr-brick-item.hbs
@@ -23,7 +23,7 @@
     <h2 class="item__head__headline">
       <a
         title={{or item.shortTitle item.title}}
-        data-label=(concat item.title " | " (or item.showTitle item.channelTitle 'NPR Article'))
+        data-label={{concat item.title " | " (or item.showTitle item.channelTitle 'NPR Article')}}
         href={{item.url}}>
           {{nypr-svg className="icon" icon="video"}}
           {{or item.shortTitle item.title}}


### PR DESCRIPTION
Changes `nypr-brick-item` headline links to use the absolute URL we get from publisher in order to support promoting content from other NYPR sites. 